### PR TITLE
support Bootstrap 4

### DIFF
--- a/_includes/layout.css
+++ b/_includes/layout.css
@@ -1,0 +1,23 @@
+nav[data-toggle='toc'] {
+  margin-top: 30px;
+}
+
+/* small screens */
+@media (max-width: 768px) {
+  /* override stickyness so that the navigation does not follow scrolling */
+  nav[data-toggle='toc'] {
+    position: relative;
+  }
+
+  /* PICK ONE */
+  /* don't expand nested items, which pushes down the rest of the page when navigating */
+  nav[data-toggle='toc'] .nav .active .nav {
+    display: none;
+  }
+  /* alternatively, if you *do* want the second-level navigation to be shown (as seen on this page on mobile), use this */
+  /*
+  nav[data-toggle='toc'] .nav .nav {
+    display: block;
+  }
+  */
+}

--- a/_includes/layout.css
+++ b/_includes/layout.css
@@ -1,12 +1,13 @@
 nav[data-toggle='toc'] {
-  margin-top: 30px;
+  top: 42px;
 }
 
 /* small screens */
 @media (max-width: 768px) {
   /* override stickyness so that the navigation does not follow scrolling */
   nav[data-toggle='toc'] {
-    position: relative;
+    margin-bottom: 42px;
+    position: static;
   }
 
   /* PICK ONE */

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,7 +42,7 @@
     <div class="container">
       <div class="row">
         <div class="col-sm-3">
-          <nav id="toc" data-spy="affix" data-toggle="toc"></nav>
+          <nav id="toc" data-toggle="toc"></nav>
         </div>
         <div class="col-sm-9">
           {{ content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/screen.css" media="screen" charset="utf-8">
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     <script src="{{ site.baseurl }}/bootstrap-toc.js" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,13 +8,13 @@
     <!--[if lt IE 9]>
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
     <![endif]-->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ site.baseurl }}/bootstrap-toc.css" media="screen" charset="utf-8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/screen.css" media="screen" charset="utf-8">
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     <script src="{{ site.baseurl }}/bootstrap-toc.js" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"></script>
     <script type="text/javascript">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,12 +8,13 @@
     <!--[if lt IE 9]>
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
     <![endif]-->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ site.baseurl }}/bootstrap-toc.css" media="screen" charset="utf-8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/screen.css" media="screen" charset="utf-8">
-    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js" integrity="sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
     <script src="{{ site.baseurl }}/bootstrap-toc.js" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"></script>
     <script type="text/javascript">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,7 +42,7 @@
     <div class="container">
       <div class="row">
         <div class="col-sm-3">
-          <nav id="toc" data-toggle="toc"></nav>
+          <nav id="toc" data-toggle="toc" class="sticky-top"></nav>
         </div>
         <div class="col-sm-9">
           {{ content }}

--- a/assets/screen.css
+++ b/assets/screen.css
@@ -7,6 +7,9 @@
   padding-top: 40px;
   padding-bottom: 40px;
 }
+nav {
+  top: 42px;
+}
 
 .hint {
   color: #563d7c;

--- a/assets/screen.css
+++ b/assets/screen.css
@@ -1,3 +1,8 @@
+---
+---
+
+{% include layout.css %}
+
 .right .github-fork-ribbon {
   background-color: #563d7c;
 }
@@ -6,9 +11,6 @@
   max-width: 800px;
   padding-top: 40px;
   padding-bottom: 40px;
-}
-nav {
-  top: 42px;
 }
 
 .hint {
@@ -34,16 +36,6 @@ footer {
 
 /* small screens */
 @media (max-width: 768px) {
-  /* override the Affix plugin so that the navigation isn't sticky */
-  nav.affix[data-toggle='toc'] {
-    position: static;
-  }
-
-  /* display the second-level nav */
-  nav[data-toggle='toc'] .nav .nav {
-    display: block;
-  }
-
   .hint {
     top: 0;
   }

--- a/bootstrap-toc.css
+++ b/bootstrap-toc.css
@@ -48,9 +48,9 @@ nav[data-toggle='toc'] .nav .nav > li > a:hover,
 nav[data-toggle='toc'] .nav .nav > li > a:focus {
   padding-left: 29px;
 }
-nav[data-toggle='toc'] .nav .nav > .active > a,
-nav[data-toggle='toc'] .nav .nav > .active:hover > a,
-nav[data-toggle='toc'] .nav .nav > .active:focus > a {
+nav[data-toggle='toc'] .nav .nav > li > .active,
+nav[data-toggle='toc'] .nav .nav > li > .active:hover,
+nav[data-toggle='toc'] .nav .nav > li > .active:focus {
   padding-left: 28px;
   font-weight: 500;
 }

--- a/bootstrap-toc.css
+++ b/bootstrap-toc.css
@@ -21,9 +21,9 @@ nav[data-toggle='toc'] .nav > li > a:focus {
   background-color: transparent;
   border-left: 1px solid #563d7c;
 }
-nav[data-toggle='toc'] .nav > .active > a,
-nav[data-toggle='toc'] .nav > .active:hover > a,
-nav[data-toggle='toc'] .nav > .active:focus > a {
+nav[data-toggle='toc'] .nav-link.active,
+nav[data-toggle='toc'] .nav-link.active:hover,
+nav[data-toggle='toc'] .nav-link.active:focus {
   padding-left: 18px;
   font-weight: bold;
   color: #563d7c;
@@ -32,10 +32,11 @@ nav[data-toggle='toc'] .nav > .active:focus > a {
 }
 
 /* Nav: second level (shown on .active) */
-nav[data-toggle='toc'] .nav .nav {
+nav[data-toggle='toc'] .nav-link + ul {
   display: none; /* Hide by default, but at >768px, show it */
   padding-bottom: 10px;
 }
+
 nav[data-toggle='toc'] .nav .nav > li > a {
   padding-top: 1px;
   padding-bottom: 1px;
@@ -54,8 +55,7 @@ nav[data-toggle='toc'] .nav .nav > .active:focus > a {
   font-weight: 500;
 }
 
-/* from https://github.com/twbs/bootstrap/blob/e38f066d8c203c3e032da0ff23cd2d6098ee2dd6/docs/assets/css/src/docs.css#L631-L634 */
-nav[data-toggle='toc'] .nav > .active > ul {
+nav[data-toggle='toc'] .nav-link.active + ul {
   display: block;
 }
 

--- a/bootstrap-toc.css
+++ b/bootstrap-toc.css
@@ -58,7 +58,3 @@ nav[data-toggle='toc'] .nav .nav > li > .active:focus {
 nav[data-toggle='toc'] .nav-link.active + ul {
   display: block;
 }
-
-nav[data-toggle='toc'].sticky-top {
-  top: 42px;
-}

--- a/bootstrap-toc.css
+++ b/bootstrap-toc.css
@@ -59,8 +59,6 @@ nav[data-toggle='toc'] .nav-link.active + ul {
   display: block;
 }
 
-nav[data-toggle='toc'] {
+nav[data-toggle='toc'].sticky-top {
   top: 42px;
-  position: -webkit-sticky;
-  position: sticky;
 }

--- a/bootstrap-toc.css
+++ b/bootstrap-toc.css
@@ -58,3 +58,9 @@ nav[data-toggle='toc'] .nav .nav > .active:focus > a {
 nav[data-toggle='toc'] .nav > .active > ul {
   display: block;
 }
+
+nav[data-toggle='toc'] {
+  top: 42px;
+  position: -webkit-sticky;
+  position: sticky;
+}

--- a/bootstrap-toc.js
+++ b/bootstrap-toc.js
@@ -47,7 +47,7 @@
       },
 
       createNavList: function() {
-        return $('<ul class="nav"></ul>');
+        return $('<ul class="nav navbar-nav"></ul>');
       },
 
       createChildNavList: function($parent) {
@@ -57,7 +57,7 @@
       },
 
       generateNavEl: function(anchor, text) {
-        var $a = $('<a></a>');
+        var $a = $('<a class="nav-link"></a>');
         $a.attr('href', '#' + anchor);
         $a.text(text);
         var $li = $('<li></li>');

--- a/index.md
+++ b/index.md
@@ -131,27 +131,7 @@ This plugin isn't opinionated about where it should be placed on the page, but a
 You may also want to include this in your stylesheet:
 
 ```css
-nav[data-toggle='toc'] {
-  margin-top: 30px;
-}
-
-/* small screens */
-@media (max-width: 768px) {
-  /* override stickyness so that the navigation does not follow scrolling */
-  nav[data-toggle='toc'] {
-    position: relative;
-  }
-
-  /* PICK ONE */
-  /* don't expand nested items, which pushes down the rest of the page when navigating */
-  nav[data-toggle='toc'] .nav .active .nav {
-    display: none;
-  }
-  /* alternatively, if you *do* want the second-level navigation to be shown (as seen on this page on mobile), use this */
-  nav[data-toggle='toc'] .nav .nav {
-    display: block;
-  }
-}
+{% include layout.css %}
 ```
 
 ## Examples

--- a/index.md
+++ b/index.md
@@ -134,9 +134,12 @@ You may also want to include this in your stylesheet:
 {% include layout.css %}
 ```
 
+ _Note: if you're upgrading from version <= 0.4.1 to 1.0.0+, these have changed._
+
 ## Examples
 
 * [Advanced JS course syllabus](https://advanced-js.github.io/syllabus/)
+* [aws-http](https://rishikeshdarandale.github.io/aws-http/)
 * [OpenStreetMap Carto Tutorials](https://ircama.github.io/osm-carto-tutorials/tile-server-ubuntu/)
 
 ## See also

--- a/index.md
+++ b/index.md
@@ -108,7 +108,7 @@ To prevent a particular heading from being added to the table of contents, add a
 
 ## Layout
 
-This plugin isn't opinionated about where it should be placed on the page, but a common use case is to have the table of contents created as a "sticky" sidebar. We will leverage the [Affix](http://getbootstrap.com/javascript/#affix) plugin for this, and wrap the `<nav>` element in a `<div>` with a Bootstrap column class (see information about the [Grid](http://getbootstrap.com/css/#grid)). As an example putting it all together (similar to this page):
+This plugin isn't opinionated about where it should be placed on the page, but a common use case is to have the table of contents created as a "sticky" sidebar. ~~We will leverage the [Affix](http://getbootstrap.com/javascript/#affix) plugin for this, and wrap the `<nav>` element in a `<div>` with a Bootstrap column class (see information about the [Grid](http://getbootstrap.com/css/#grid)). As an example putting it all together (similar to this page):~~ [Affix](http://getbootstrap.com/javascript/#affix) has been deprecated as of Bootstrap 4.0 ([reference](https://v4-alpha.getbootstrap.com/migration/#components)). bootstrap-toc now uses `position: sticky;` instead.
 
 ```html
 <body data-spy="scroll" data-target="#toc">
@@ -116,7 +116,7 @@ This plugin isn't opinionated about where it should be placed on the page, but a
     <div class="row">
       <!-- sidebar, which will move to the top on a small screen -->
       <div class="col-sm-3">
-        <nav id="toc" data-spy="affix" data-toggle="toc"></nav>
+        <nav id="toc" data-toggle="toc"></nav>
       </div>
       <!-- main content area -->
       <div class="col-sm-9">
@@ -136,9 +136,9 @@ nav[data-toggle='toc'] {
 
 /* small screens */
 @media (max-width: 768px) {
-  /* override the Affix plugin so that the navigation isn't sticky */
-  nav.affix[data-toggle='toc'] {
-    position: static;
+  /* override stickyness so that the navigation does not follow scrolling */
+  nav[data-toggle='toc'] {
+    position: relative;
   }
 
   /* PICK ONE */

--- a/index.md
+++ b/index.md
@@ -8,24 +8,23 @@ permalink: /
 
 [![Build Status](https://travis-ci.org/afeld/bootstrap-toc.svg?branch=gh-pages)](https://travis-ci.org/afeld/bootstrap-toc)
 
-This [Bootstrap](http://getbootstrap.com/) plugin allows you to generate a table of contents for any page, based on the heading elements (`<h1>`, `<h2>`, etc.). It is meant to emulate the sidebar you see on [the Bootstrap documentation site](http://getbootstrap.com/css/).
+This [Bootstrap](http://getbootstrap.com/) plugin allows you to generate a table of contents for any page, based on the heading elements (`<h1>`, `<h2>`, etc.). It is meant to emulate the sidebar you see on [the Bootstrap v3 documentation site](https://getbootstrap.com/docs/3.3/css/).
 
 This page is an example of the plugin in action – the table of contents you see on the left (or top, on mobile) was automatically generated, without having to manually keep all of the navigation items in sync with the headings.
 
 ## Usage
 
-On top of the normal Bootstrap setup (see their [Getting Started](http://getbootstrap.com/getting-started/) guide), you will need to include the Bootstrap Table of Contents stylesheet and JavaScript file.
+1. Set up Bootstrap v3 or v4.
+1. Include the Bootstrap Table of Contents stylesheet and JavaScript file. [Unminified versions](https://github.com/afeld/bootstrap-toc/tree/gh-pages/dist) are also available.
 
-```html
-<!-- add after bootstrap.min.css -->
-<link rel="stylesheet" href="https://cdn.rawgit.com/afeld/bootstrap-toc/v0.4.1/dist/bootstrap-toc.min.css">
-<!-- add after bootstrap.min.js -->
-<script src="https://cdn.rawgit.com/afeld/bootstrap-toc/v0.4.1/dist/bootstrap-toc.min.js"></script>
-```
+    ```html
+    <!-- add after bootstrap.min.css -->
+    <link rel="stylesheet" href="https://cdn.rawgit.com/afeld/bootstrap-toc/v0.4.1/dist/bootstrap-toc.min.css">
+    <!-- add after bootstrap.min.js -->
+    <script src="https://cdn.rawgit.com/afeld/bootstrap-toc/v0.4.1/dist/bootstrap-toc.min.js"></script>
+    ```
 
-[Unminified versions](https://github.com/afeld/bootstrap-toc/tree/gh-pages/dist) are also available.
-
-Next, pick one of the two options below.
+1. Pick one of the two options below.
 
 ### Via data attributes
 

--- a/index.md
+++ b/index.md
@@ -109,7 +109,7 @@ To prevent a particular heading from being added to the table of contents, add a
 
 ## Layout
 
-This plugin isn't opinionated about where it should be placed on the page, but a common use case is to have the table of contents created as a "sticky" sidebar.
+This plugin isn't opinionated about where it should be placed on the page, but a common use case is to have the table of contents created as a ["sticky"](https://getbootstrap.com/docs/4.0/utilities/position/#sticky-top) sidebar.
 
 ```html
 <body data-spy="scroll" data-target="#toc">
@@ -117,7 +117,7 @@ This plugin isn't opinionated about where it should be placed on the page, but a
     <div class="row">
       <!-- sidebar, which will move to the top on a small screen -->
       <div class="col-sm-3">
-        <nav id="toc" data-toggle="toc"></nav>
+        <nav id="toc" data-toggle="toc" class="sticky-top"></nav>
       </div>
       <!-- main content area -->
       <div class="col-sm-9">

--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ Create a `<nav>` element with a `data-toggle="toc"` attribute.
 <nav id="toc" data-toggle="toc"></nav>
 ```
 
-You can put this wherever on the page you like. Since this plugin leverages Bootstrap's [Scrollspy](http://getbootstrap.com/javascript/#scrollspy) plugin, you will also need to add a couple attributes to the `<body>`:
+You can put this wherever on the page you like. Since this plugin leverages Bootstrap's [Scrollspy](https://getbootstrap.com/docs/4.0/components/scrollspy/) plugin, you will also need to add a couple attributes to the `<body>`:
 
 ```html
 <body data-spy="scroll" data-target="#toc">
@@ -64,7 +64,7 @@ $(function() {
 });
 ```
 
-See the [Scrollspy](http://getbootstrap.com/javascript/#scrollspy) documentation for more information about initializing that plugin.
+See the [Scrollspy](https://getbootstrap.com/docs/4.0/components/scrollspy/) documentation for more information about initializing that plugin.
 
 #### Options
 

--- a/index.md
+++ b/index.md
@@ -14,7 +14,8 @@ This page is an example of the plugin in action – the table of contents you se
 
 ## Usage
 
-1. Set up Bootstrap v3 or v4.
+1. Set up Bootstrap v4.
+    * For Bootstrap v3, see [the older instructions](https://github.com/afeld/bootstrap-toc/blob/v0.4.1/index.md#usage).
 1. Include the Bootstrap Table of Contents stylesheet and JavaScript file. [Unminified versions](https://github.com/afeld/bootstrap-toc/tree/gh-pages/dist) are also available.
 
     ```html
@@ -108,7 +109,7 @@ To prevent a particular heading from being added to the table of contents, add a
 
 ## Layout
 
-This plugin isn't opinionated about where it should be placed on the page, but a common use case is to have the table of contents created as a "sticky" sidebar. ~~We will leverage the [Affix](http://getbootstrap.com/javascript/#affix) plugin for this, and wrap the `<nav>` element in a `<div>` with a Bootstrap column class (see information about the [Grid](http://getbootstrap.com/css/#grid)). As an example putting it all together (similar to this page):~~ [Affix](http://getbootstrap.com/javascript/#affix) has been deprecated as of Bootstrap 4.0 ([reference](https://v4-alpha.getbootstrap.com/migration/#components)). bootstrap-toc now uses `position: sticky;` instead.
+This plugin isn't opinionated about where it should be placed on the page, but a common use case is to have the table of contents created as a "sticky" sidebar.
 
 ```html
 <body data-spy="scroll" data-target="#toc">

--- a/test/toc-test.js
+++ b/test/toc-test.js
@@ -119,15 +119,15 @@ describe('Toc', function() {
       });
 
       expect($nav.html()).to.eql(
-        '<ul class="nav">' +
+        '<ul class="nav navbar-nav">' +
           '<li>' +
-            '<a href="#h1">H1</a>' +
+            '<a class="nav-link" href="#h1">H1</a>' +
           '</li>' +
           '<li>' +
-            '<a href="#h1-1">H1</a>' +
+            '<a class="nav-link" href="#h1-1">H1</a>' +
           '</li>' +
           '<li>' +
-            '<a href="#h1-2">H1</a>' +
+            '<a class="nav-link" href="#h1-2">H1</a>' +
           '</li>' +
         '</ul>'
       );
@@ -146,12 +146,12 @@ describe('Toc', function() {
       });
 
       expect($nav.html()).to.eql(
-        '<ul class="nav">' +
+        '<ul class="nav navbar-nav">' +
           '<li>' +
-            '<a href="#h1">H1</a>' +
+            '<a class="nav-link" href="#h1">H1</a>' +
           '</li>' +
           '<li>' +
-            '<a href="#h1-1">H1</a>' +
+            '<a class="nav-link" href="#h1-1">H1</a>' +
           '</li>' +
         '</ul>'
       );
@@ -172,17 +172,17 @@ describe('Toc', function() {
       });
 
       expect($nav.html()).to.eql(
-        '<ul class="nav">' +
+        '<ul class="nav navbar-nav">' +
           '<li>' +
-            '<a href="#h2">H2</a>' +
-            '<ul class="nav">' +
+            '<a class="nav-link" href="#h2">H2</a>' +
+            '<ul class="nav navbar-nav">' +
               '<li>' +
-                '<a href="#h3">H3</a>' +
+                '<a class="nav-link" href="#h3">H3</a>' +
               '</li>' +
             '</ul>' +
           '</li>' +
           '<li>' +
-            '<a href="#h2-1">H2-1</a>' +
+            '<a class="nav-link" href="#h2-1">H2-1</a>' +
           '</li>' +
         '</ul>'
       );
@@ -199,9 +199,9 @@ describe('Toc', function() {
       });
 
       expect($nav.html()).to.eql(
-        '<ul class="nav">' +
+        '<ul class="nav navbar-nav">' +
           '<li>' +
-            '<a href="#h1">H1</a>' +
+            '<a class="nav-link" href="#h1">H1</a>' +
           '</li>' +
         '</ul>'
       );


### PR DESCRIPTION
Closes #39.

* [x] Upgrade Bootstrap in demo site
* [x] Switch from using Affix component ([support was dropped](https://v4-alpha.getbootstrap.com/migration/#components))
* [x] Fix ScrollSpy
* [ ] ~~Ensure backwards-compatibility (create a separate test page for Bootstrap 3)~~