### PR TITLE
#40 Bootstrap 4 - Steps 1-3

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,7 +42,7 @@
     <div class="container">
       <div class="row">
         <div class="col-sm-3">
-          <nav id="toc" data-spy="affix" data-toggle="toc"></nav>
+          <nav id="toc" data-toggle="toc"></nav>
         </div>
         <div class="col-sm-9">
           {{ content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,13 +8,13 @@
     <!--[if lt IE 9]>
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
     <![endif]-->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ site.baseurl }}/bootstrap-toc.css" media="screen" charset="utf-8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/screen.css" media="screen" charset="utf-8">
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     <script src="{{ site.baseurl }}/bootstrap-toc.js" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"></script>
     <script type="text/javascript">

--- a/bootstrap-toc.css
+++ b/bootstrap-toc.css
@@ -21,9 +21,9 @@ nav[data-toggle='toc'] .nav > li > a:focus {
   background-color: transparent;
   border-left: 1px solid #563d7c;
 }
-nav[data-toggle='toc'] .nav > .active > a,
-nav[data-toggle='toc'] .nav > .active:hover > a,
-nav[data-toggle='toc'] .nav > .active:focus > a {
+nav[data-toggle='toc'] .nav-link.active,
+nav[data-toggle='toc'] .nav-link.active:hover,
+nav[data-toggle='toc'] .nav-link.active:focus {
   padding-left: 18px;
   font-weight: bold;
   color: #563d7c;
@@ -32,10 +32,11 @@ nav[data-toggle='toc'] .nav > .active:focus > a {
 }
 
 /* Nav: second level (shown on .active) */
-nav[data-toggle='toc'] .nav .nav {
+nav[data-toggle='toc'] .nav-link + ul {
   display: none; /* Hide by default, but at >768px, show it */
   padding-bottom: 10px;
 }
+
 nav[data-toggle='toc'] .nav .nav > li > a {
   padding-top: 1px;
   padding-bottom: 1px;
@@ -54,8 +55,7 @@ nav[data-toggle='toc'] .nav .nav > .active:focus > a {
   font-weight: 500;
 }
 
-/* from https://github.com/twbs/bootstrap/blob/e38f066d8c203c3e032da0ff23cd2d6098ee2dd6/docs/assets/css/src/docs.css#L631-L634 */
-nav[data-toggle='toc'] .nav > .active > ul {
+nav[data-toggle='toc'] .nav-link.active + ul {
   display: block;
 }
 

--- a/bootstrap-toc.css
+++ b/bootstrap-toc.css
@@ -58,3 +58,9 @@ nav[data-toggle='toc'] .nav .nav > .active:focus > a {
 nav[data-toggle='toc'] .nav > .active > ul {
   display: block;
 }
+
+nav[data-toggle='toc'] {
+  top: 42px;
+  position: -webkit-sticky;
+  position: sticky;
+}

--- a/bootstrap-toc.js
+++ b/bootstrap-toc.js
@@ -47,7 +47,7 @@
       },
 
       createNavList: function() {
-        return $('<ul class="nav"></ul>');
+        return $('<ul class="nav navbar-nav"></ul>');
       },
 
       createChildNavList: function($parent) {
@@ -57,7 +57,7 @@
       },
 
       generateNavEl: function(anchor, text) {
-        var $a = $('<a></a>');
+        var $a = $('<a class="nav-link"></a>');
         $a.attr('href', '#' + anchor);
         $a.text(text);
         var $li = $('<li></li>');

--- a/index.md
+++ b/index.md
@@ -108,7 +108,7 @@ To prevent a particular heading from being added to the table of contents, add a
 
 ## Layout
 
-This plugin isn't opinionated about where it should be placed on the page, but a common use case is to have the table of contents created as a "sticky" sidebar. We will leverage the [Affix](http://getbootstrap.com/javascript/#affix) plugin for this, and wrap the `<nav>` element in a `<div>` with a Bootstrap column class (see information about the [Grid](http://getbootstrap.com/css/#grid)). As an example putting it all together (similar to this page):
+This plugin isn't opinionated about where it should be placed on the page, but a common use case is to have the table of contents created as a "sticky" sidebar. ~~We will leverage the [Affix](http://getbootstrap.com/javascript/#affix) plugin for this, and wrap the `<nav>` element in a `<div>` with a Bootstrap column class (see information about the [Grid](http://getbootstrap.com/css/#grid)). As an example putting it all together (similar to this page):~~ [Affix](http://getbootstrap.com/javascript/#affix) has been deprecated as of Bootstrap 4.0 ([reference](https://v4-alpha.getbootstrap.com/migration/#components)). bootstrap-toc now uses `position: sticky;` instead.
 
 ```html
 <body data-spy="scroll" data-target="#toc">
@@ -116,7 +116,7 @@ This plugin isn't opinionated about where it should be placed on the page, but a
     <div class="row">
       <!-- sidebar, which will move to the top on a small screen -->
       <div class="col-sm-3">
-        <nav id="toc" data-spy="affix" data-toggle="toc"></nav>
+        <nav id="toc" data-toggle="toc"></nav>
       </div>
       <!-- main content area -->
       <div class="col-sm-9">
@@ -136,9 +136,9 @@ nav[data-toggle='toc'] {
 
 /* small screens */
 @media (max-width: 768px) {
-  /* override the Affix plugin so that the navigation isn't sticky */
-  nav.affix[data-toggle='toc'] {
-    position: static;
+  /* override stickyness so that the navigation does not follow scrolling */
+  nav[data-toggle='toc'] {
+    position: relative;
   }
 
   /* PICK ONE */

--- a/test/toc-test.js
+++ b/test/toc-test.js
@@ -119,15 +119,15 @@ describe('Toc', function() {
       });
 
       expect($nav.html()).to.eql(
-        '<ul class="nav">' +
+        '<ul class="nav navbar-nav">' +
           '<li>' +
-            '<a href="#h1">H1</a>' +
+            '<a class="nav-link" href="#h1">H1</a>' +
           '</li>' +
           '<li>' +
-            '<a href="#h1-1">H1</a>' +
+            '<a class="nav-link" href="#h1-1">H1</a>' +
           '</li>' +
           '<li>' +
-            '<a href="#h1-2">H1</a>' +
+            '<a class="nav-link" href="#h1-2">H1</a>' +
           '</li>' +
         '</ul>'
       );
@@ -146,12 +146,12 @@ describe('Toc', function() {
       });
 
       expect($nav.html()).to.eql(
-        '<ul class="nav">' +
+        '<ul class="nav navbar-nav">' +
           '<li>' +
-            '<a href="#h1">H1</a>' +
+            '<a class="nav-link" href="#h1">H1</a>' +
           '</li>' +
           '<li>' +
-            '<a href="#h1-1">H1</a>' +
+            '<a class="nav-link" href="#h1-1">H1</a>' +
           '</li>' +
         '</ul>'
       );
@@ -172,17 +172,17 @@ describe('Toc', function() {
       });
 
       expect($nav.html()).to.eql(
-        '<ul class="nav">' +
+        '<ul class="nav navbar-nav">' +
           '<li>' +
-            '<a href="#h2">H2</a>' +
-            '<ul class="nav">' +
+            '<a class="nav-link" href="#h2">H2</a>' +
+            '<ul class="nav navbar-nav">' +
               '<li>' +
-                '<a href="#h3">H3</a>' +
+                '<a class="nav-link" href="#h3">H3</a>' +
               '</li>' +
             '</ul>' +
           '</li>' +
           '<li>' +
-            '<a href="#h2-1">H2-1</a>' +
+            '<a class="nav-link" href="#h2-1">H2-1</a>' +
           '</li>' +
         '</ul>'
       );
@@ -199,9 +199,9 @@ describe('Toc', function() {
       });
 
       expect($nav.html()).to.eql(
-        '<ul class="nav">' +
+        '<ul class="nav navbar-nav">' +
           '<li>' +
-            '<a href="#h1">H1</a>' +
+            '<a class="nav-link" href="#h1">H1</a>' +
           '</li>' +
         '</ul>'
       );


### PR DESCRIPTION
- [x] Upgrade Bootstrap (to 4.0) in demo site
- [x] Switch from using Affix component (support was dropped)
- [x] Fix ScrollSpy
- [ ] Ensure backwards-compatibility (create a separate test page for Bootstrap 3)

Known issues:
- On the test templates, ScrollSpy does not highlight the last entry when you scroll to the bottom of the page. This behaviour was not present previously