### PR TITLE
mark the project as unmaintained?

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,6 +5,8 @@ permalink: /
 
 # Table of Contents plugin for Bootstrap
 
+***This plugin is no longer maintained. For an alternative, see [Tocbot](https://tscanlin.github.io/tocbot/).***
+
 [![Build Status](https://travis-ci.org/afeld/bootstrap-toc.svg?branch=gh-pages)](https://travis-ci.org/afeld/bootstrap-toc)
 
 This [Bootstrap](http://getbootstrap.com/) plugin allows you to generate a table of contents for any page, based on the heading elements (`<h1>`, `<h2>`, etc.). It is meant to emulate the sidebar you see on [the Bootstrap v3 documentation site](https://getbootstrap.com/docs/3.3/css/).


### PR DESCRIPTION
I started looking into what it would take to:

- Generally bring this project up to date
- Decouple from jQuery (https://github.com/afeld/bootstrap-toc/issues/72)
- Decouple from Bootstrap (https://github.com/afeld/bootstrap-toc/issues/16)

and realized it was going to be a decent bit of work. Meanwhile, [Tocbot](https://tscanlin.github.io/tocbot/) (and probably other alternatives) are available, and look a lot like what Bootstrap TOC would look like on the other side of all those changes. In addition, Bootstrap TOC would probably need a new name to avoid confusion, since:

- It would no longer leverage Bootstrap
- Neither the Bootstrap [4](https://getbootstrap.com/docs/4.5/getting-started/introduction/) or [5](https://getbootstrap.com/docs/5.0/getting-started/introduction/) docs have the highlight+expand-on-scroll behavior this plugin was meant to mimic

Therefore, unless someone else is interested in taking over maintenance, I think this project has run it's course. If I don't hear from anyone in the next week or so, I'll merge this and archive the repository.

CCing folks who have been active most recently: @bopeng @pustur @sneyed @fedetask 